### PR TITLE
Revert deprecation message formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,11 +123,7 @@ import { deprecate } from 'debug-tools';
 
 let foo = 2;
 
-deprecate('This is deprecated.', foo % 2, {
-  id: 'old-and-busted',
-  url: 'http://example.com',
-  until: '4.0.0'
-});
+deprecate('This is deprecated.', foo % 2);
 ```
 
 Expands into:
@@ -137,7 +133,7 @@ const DEBUG = 1;
 
 let foo = 2;
 
-(DEBUG && foo % 2 && console.warn('DEPRECATED [old-and-busted]: This is deprecated. Will be removed in 4.0.0. Please see http://example.com for more details.'));
+(DEBUG && foo % 2 && console.warn('This is deprecated.'));
 ```
 
 ## Externalized Helpers

--- a/fixtures/deprecate-expansion/expectation.js
+++ b/fixtures/deprecate-expansion/expectation.js
@@ -1,2 +1,2 @@
 const DEBUG = 1;
-(DEBUG && true && console.warn('DEPRECATED [a-thing]: This is deprecated. Will be removed in 3.0.0. See http://example.com for more information.'));
+(DEBUG && true && console.warn('This is deprecated'));

--- a/fixtures/deprecate-expansion/sample.js
+++ b/fixtures/deprecate-expansion/sample.js
@@ -1,8 +1,4 @@
 import { DEBUG } from '@ember/env-flags';
 import { deprecate } from '@ember/debug-tools';
 
-deprecate('This is deprecated', true, {
-  until: '3.0.0',
-  id: 'a-thing',
-  url: 'http://example.com'
-});
+deprecate('This is deprecated', true);

--- a/fixtures/global-external-helpers/expectation.js
+++ b/fixtures/global-external-helpers/expectation.js
@@ -1,4 +1,8 @@
 const _DEBUG = 1;
 (_DEBUG && __debugHelpers__.warn('This is a warning'));
 (_DEBUG && __debugHelpers__.assert(false, 'Hahahaha'));
-(_DEBUG && true && __debugHelpers__.deprecate('DEPRECATED [donzo]: This thing is donzo. Will be removed in 4.0.0. See http://example.com for more information.'));
+(_DEBUG && true && __debugHelpers__.deprecate('This thing is donzo', {
+  id: 'donzo',
+  until: '4.0.0',
+  url: 'http://example.com'
+}));

--- a/fixtures/hygenic-debug-injection/expectation.js
+++ b/fixtures/hygenic-debug-injection/expectation.js
@@ -4,5 +4,5 @@ import bar from 'something';
 
 if (bar()) {
   const DEBUG = 'hahah';
-  (_DEBUG && true && console.warn('DEPRECATED [a-thing]: This is deprecated. Will be removed in 3.0.0. See http://example.com for more information.'));
+  (_DEBUG && true && console.warn('This is deprecated'));
 }

--- a/fixtures/retain-module-external-helpers/expectation.js
+++ b/fixtures/retain-module-external-helpers/expectation.js
@@ -3,4 +3,8 @@ import { warn, assert, deprecate } from '@ember/debug-tools';
 
 (_DEBUG && warn('This is a warning'));
 (_DEBUG && assert(false, 'Hahahaha'));
-(_DEBUG && true && deprecate('DEPRECATED [donzo]: This thing is donzo. Will be removed in 4.0.0. See http://example.com for more information.'));
+(_DEBUG && true && deprecate('This thing is donzo', {
+  id: 'donzo',
+  until: '4.0.0',
+  url: 'http://example.com'
+}));

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 import { normalizeOptions } from './lib/utils/normalize-options';
 
-export default function (babel) {
+function macros(babel) {
   const { types: t } = babel;
   let macroBuilder;
   let options;
@@ -15,16 +15,16 @@ export default function (babel) {
       Program: {
         enter(path, state) {
           options = normalizeOptions(state.opts);
-          macroBuilder = new Macros(t, options);
+          this.macroBuilder = new Macros(t, options);
         },
 
         exit(path) {
-          if (macroBuilder.importedDebugTools) {
-            macroBuilder.expand(path);
+          if (this.macroBuilder.importedDebugTools) {
+            this.macroBuilder.expand(path);
           }
 
-          if (macroBuilder.hasEnvFlags) {
-            macroBuilder.inlineEnvFlags(path);
+          if (this.macroBuilder.hasEnvFlags) {
+            this.macroBuilder.inlineEnvFlags(path);
           }
         }
       },
@@ -41,17 +41,23 @@ export default function (babel) {
         let isFeaturesImport = featureImportSpecifiers.includes(importPath);
 
         if (isFeaturesImport && !flags.DEBUG) {
-          macroBuilder.inlineFeatureFlags(path);
+          this.macroBuilder.inlineFeatureFlags(path);
         } else if (debugToolsImport && debugToolsImport === importPath) {
-          macroBuilder.collectDebugToolsSpecifiers(path.get('specifiers'));
+          this.macroBuilder.collectDebugToolsSpecifiers(path.get('specifiers'));
         } if (envFlagsImport && envFlagsImport === importPath) {
-          macroBuilder.collectEnvFlagSpecifiers(path.get('specifiers'));
+          this.macroBuilder.collectEnvFlagSpecifiers(path.get('specifiers'));
         }
       },
 
       ExpressionStatement(path) {
-        macroBuilder.build(path);
+        this.macroBuilder.build(path);
       }
     }
   };
 }
+
+macros.cacheKey = function() {
+  return macros.toString();
+}
+
+export default macros;

--- a/src/tests/debug-tools-test.js
+++ b/src/tests/debug-tools-test.js
@@ -300,28 +300,39 @@ Object.keys(cases).forEach(caseName => {
     let ep = 0;
 
     cases[caseName].fixtures.forEach(assertionName => {
-      it(assertionName, () => {
-        let sample = file(`./fixtures/${assertionName}/sample.js`).content;
-        let options = cases[caseName].transformOptions;
-        let expectationPath = `./fixtures/${assertionName}/expectation.js`;
-        let expectationExists = true;
-
-        try {
-          lstatSync(expectationPath);
-        } catch (e) {
-          expectationExists = false
-        }
-
-        if (expectationExists) {
-          let expectation = file(`./fixtures/${assertionName}/expectation.js`).content;
-          let compiled = compile(sample, options);
-          expect(compiled.code).to.equal(expectation);
-
-        } else {
-          let fn = () => compile(sample, options);
-          expect(fn).to.throw(new RegExp(cases[caseName].errors[ep++]));
-        }
-      });
+      if (cases[caseName].only) {
+        it.only(assertionName, () => {
+          test(caseName, cases, assertionName, ep);
+        });
+      } else {
+        it(assertionName, () => {
+          test(caseName, cases, assertionName, ep);
+        });
+      }
     });
   });
 });
+
+
+function test(caseName, cases, assertionName, ep) {
+  let sample = file(`./fixtures/${assertionName}/sample.js`).content;
+  let options = cases[caseName].transformOptions;
+  let expectationPath = `./fixtures/${assertionName}/expectation.js`;
+  let expectationExists = true;
+
+  try {
+    lstatSync(expectationPath);
+  } catch (e) {
+    expectationExists = false
+  }
+
+  if (expectationExists) {
+    let expectation = file(`./fixtures/${assertionName}/expectation.js`).content;
+    let compiled = compile(sample, options);
+    expect(compiled.code).to.equal(expectation);
+
+  } else {
+    let fn = () => compile(sample, options);
+    expect(fn).to.throw(new RegExp(cases[caseName].errors[ep++]));
+  }
+}


### PR DESCRIPTION
I didn't realize how often in ember we join in some dynamic content into the deprecation message making auto formatting difficult. Also add mocha "only" option to test runner simply slot `only: true` onto the test.