### PR TITLE
Only replace envFlag if it is an import of envFlagsSource.

### DIFF
--- a/fixtures/does-not-modify-non-imported-flags/expectation.js
+++ b/fixtures/does-not-modify-non-imported-flags/expectation.js
@@ -1,0 +1,5 @@
+const DEBUG = 1;
+
+if (DEBUG) {
+  console.log('do it!');
+}

--- a/fixtures/does-not-modify-non-imported-flags/sample.js
+++ b/fixtures/does-not-modify-non-imported-flags/sample.js
@@ -1,0 +1,5 @@
+const DEBUG = 1;
+
+if (DEBUG) {
+  console.log('do it!');
+}

--- a/src/lib/utils/macros.js
+++ b/src/lib/utils/macros.js
@@ -72,7 +72,10 @@ export default class Macros {
     let { envFlags, builder } = this;
     Object.keys(envFlags).forEach(flag => {
        let binding = path.scope.getBinding(flag);
-       if (binding) {
+       if (binding &&
+          binding.path.isImportSpecifier() &&
+          binding.path.parent.source.value === this.envFlagsSource) {
+
          binding.referencePaths.forEach(p => p.replaceWith(builder.t.booleanLiteral(envFlags[flag])));
        }
     });

--- a/src/tests/debug-tools-test.js
+++ b/src/tests/debug-tools-test.js
@@ -253,7 +253,8 @@ let cases = {
       ]
     },
     fixtures: [
-      'retains-import-for-non-macro-types'
+      'retains-import-for-non-macro-types',
+      'does-not-modify-non-imported-flags'
     ]
   },
 


### PR DESCRIPTION
Fix #34