### PR TITLE
Revert "Update predicate based macros replace predicate when prefixing with it."

### DIFF
--- a/fixtures/assert-expansion/expectation.js
+++ b/fixtures/assert-expansion/expectation.js
@@ -1,2 +1,2 @@
-(true && !((() => true)()) && console.assert(false, 'This is an assertion'));
+(true && !((() => true)()) && console.assert((() => true)(), 'This is an assertion'));
 (true && !(false) && console.assert(false, 'This is an assertion 2'));

--- a/fixtures/ember-cli-babel-config/expectation.js
+++ b/fixtures/ember-cli-babel-config/expectation.js
@@ -5,9 +5,9 @@ if (true) {
 }
 
 (true && Ember.warn('This is a warning'));
-(true && !(foo) && Ember.assert('Hahahaha', false));
-(true && !(false) && Ember.assert('without predicate', false));
-(true && !(true) && Ember.deprecate('This thing is donzo', false, {
+(true && !(foo) && Ember.assert('Hahahaha', foo));
+(true && !(false) && Ember.assert('without predicate'));
+(true && !(true) && Ember.deprecate('This thing is donzo', true, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/fixtures/global-external-helpers/expectation.js
+++ b/fixtures/global-external-helpers/expectation.js
@@ -1,6 +1,6 @@
 (true && __debugHelpers__.warn('This is a warning'));
 (true && __debugHelpers__.assert('Hahahaha', foo));
-(true && !(true) && __debugHelpers__.deprecate('This thing is donzo', false, {
+(true && !(true) && __debugHelpers__.deprecate('This thing is donzo', true, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/fixtures/retain-module-external-helpers/expectation.js
+++ b/fixtures/retain-module-external-helpers/expectation.js
@@ -2,7 +2,7 @@ import { warn, assert, deprecate } from '@ember/debug-tools';
 
 (true && warn('This is a warning'));
 (true && assert('Hahahaha', false));
-(true && !(true) && deprecate('This thing is donzo', false, {
+(true && !(true) && deprecate('This thing is donzo', true, {
   id: 'donzo',
   until: '4.0.0',
   url: 'http://example.com'

--- a/src/lib/utils/builder.js
+++ b/src/lib/utils/builder.js
@@ -16,34 +16,19 @@ export default class Builder {
    *
    * ($DEBUG && console.assert($PREDICATE, $MESSAGE));
    *
-   * or (when `assertPredicateIndex` specified)
-   *
-   * ($DEBUG && $PREDICATE && console.assert(false, $MESSAGE));
-   *
-   * or (`{ externalizeHelpers: { module: true } }`)
+   * or
    *
    * ($DEBUG && assert($PREDICATE, $MESSAGE));
    *
-   * or (when `{ externalizeHelpers: { module: true }, debugTools: { source: '...', assertPredicateIndex: 0 } }` specified)
-   *
-   * ($DEBUG && $PREDICATE && assert(false, $MESSAGE));
-   *
-   * or (when `{ externalizeHelpers: { global: '$GLOBLA_NS' }` specified)
+   * or
    *
    * ($DEBUG && $GLOBAL_NS.assert($PREDICATE, $MESSAGE));
-   *
-   * or (when `{ externalizeHelpers: { global: '$GLOBLA_NS' }, debugTools: { source: '...', assertPredicateIndex: 0 } }` specified)
-   *
-   * ($DEBUG && $PREDICATE && $GLOBAL_NS.assert(false, $MESSAGE));
    */
   assert(path) {
     let predicate;
     if (this.assertPredicateIndex !== undefined) {
       predicate = (expression, args) => {
-        let predicate = args[this.assertPredicateIndex];
-        args[this.assertPredicateIndex] = this.t.identifier('false');
-
-        return predicate;
+        return args[this.assertPredicateIndex];
       };
     }
 
@@ -149,20 +134,15 @@ export default class Builder {
    *
    * or
    *
-   * ($DEBUG && $PREDICATE && deprecate($MESSAGE, false, { $ID, $URL, $UNTIL }));
+   * ($DEBUG && $PREDICATE && deprecate($MESSAGE, $PREDICATE, { $ID, $URL, $UNTIL }));
    *
    * or
    *
-   * ($DEBUG && $PREDICATE && $GLOBAL_NS.deprecate($MESSAGE, false, { $ID, $URL, $UNTIL }));
+   * ($DEBUG && $PREDICATE && $GLOBAL_NS.deprecate($MESSAGE, $PREDICATE, { $ID, $URL, $UNTIL }));
    */
   deprecate(path) {
     this._createMacroExpression(path, {
-      predicate: (expression, args) => {
-        let [, predicate] = args;
-        args[1] = this.t.identifier('false');
-
-        return predicate;
-      },
+      predicate: (expression, args) => args[1],
 
       buildConsoleAPI: (expression, args) => {
         let [message] = args;


### PR DESCRIPTION
This reverts commit ed02f7591946f7e9e47c6827a28218401143176d.

Reverting this to fix the regression that #41 attempts to fix, we can bring it back in #42.