### PR TITLE
Ensure import is removed when other tooling uses the same module.

### DIFF
--- a/fixtures/shared-debug-module/expectation.js
+++ b/fixtures/shared-debug-module/expectation.js
@@ -1,0 +1,5 @@
+var inspect = Ember.inspect;
+
+
+inspect('string thing');
+(true && !(false) && Ember.assert(false, 'This is an assertion 2'));

--- a/fixtures/shared-debug-module/sample.js
+++ b/fixtures/shared-debug-module/sample.js
@@ -1,0 +1,4 @@
+import { assert, inspect } from '@ember/debug-tools';
+
+inspect('string thing');
+assert(false, 'This is an assertion 2');

--- a/src/lib/utils/macros.js
+++ b/src/lib/utils/macros.js
@@ -7,7 +7,6 @@ const SUPPORTED_MACROS = ['assert', 'deprecate', 'warn', 'log'];
 export default class Macros {
   constructor(t, options) {
     this.localDebugBindings = [];
-    this.isImportRemovable = false;
     this.envFlagBindings = [];
     this.hasEnvFlags = false;
     this.envFlagsSource = options.envFlags.envFlagsImport;
@@ -122,9 +121,6 @@ export default class Macros {
   collectDebugToolsSpecifiers(specifiers) {
     this.importedDebugTools = true;
     this._collectImportBindings(specifiers, this.localDebugBindings);
-    if (specifiers.length === this.localDebugBindings.length) {
-      this.isImportRemovable = true;
-    }
   }
 
   collectEnvFlagSpecifiers(specifiers) {
@@ -197,7 +193,11 @@ export default class Macros {
 
     if (!debugHelpers.module) {
       if (this.localDebugBindings.length > 0) {
-        if (this.isImportRemovable) {
+        this.localDebugBindings[0].parentPath.parentPath
+        let importPath = this.localDebugBindings[0].findParent(p => p.isImportDeclaration());
+        let specifiers = importPath.get('specifiers');
+
+        if (specifiers.length === this.localDebugBindings.length) {
           this.localDebugBindings[0].parentPath.parentPath.remove();
         } else {
           this.localDebugBindings.forEach((binding) => binding.parentPath.remove());


### PR DESCRIPTION
In the default configuration of ember-cli-babel both `babel-plugin-debug-macros` and `babel-plugin-ember-modules-api-polyfill` handle specific specifiers out of `@ember/debug`. Prior to this change this package would not properly remove the import declaration (even though it had no specifiers left after both plugins had ran), because the `isImportRemovable` flag is eagerly cached.

After this change, the import is removed if the only remaining specifiers are the ones that debug-macros is removing.

Addresses the remaining issue mentioned in https://github.com/babel/ember-cli-babel/pull/161#issuecomment-312797986.