### PR TITLE
Ensure `Plugin.baseDir()` functions properly.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const path = require('path');
 const Macros = require('./utils/macros');
 const normalizeOptions = require('./utils/normalize-options').normalizeOptions;
 
@@ -53,7 +54,7 @@ function macros(babel) {
 }
 
 macros.baseDir = function() {
-  return dirname(__dirname);
+  return path.dirname(__dirname);
 }
 
 module.exports = macros;

--- a/tests/ensure-baseDir-test.js
+++ b/tests/ensure-baseDir-test.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const DebugToolsPlugin = require('..');
+
+describe('baseDir', function() {
+  it('returns directory with package.json', function() {
+    let baseDir = DebugToolsPlugin.baseDir();
+    let pkg = require(baseDir + '/package');
+
+    expect(pkg.name).toBe('babel-plugin-debug-macros');
+  });
+});


### PR DESCRIPTION
This was broken during the refactoring which removed compile step.