### PR TITLE
Cleanup / fix some svelte related functionality.

### DIFF
--- a/fixtures/development-svelte-builds/expectation6.js
+++ b/fixtures/development-svelte-builds/expectation6.js
@@ -11,6 +11,10 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
+if (DEPRECATED_PARTIALS && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 if (DEPRECATED_CONTROLLERS) {
   ObjectController = class {

--- a/fixtures/development-svelte-builds/expectation6.js
+++ b/fixtures/development-svelte-builds/expectation6.js
@@ -12,6 +12,8 @@ if (DEPRECATED_PARTIALS) {
 }
 
 if (DEPRECATED_PARTIALS && someOtherThing()) {
+  throw new Error('You indicated you don\'t have any deprecations, however you are relying on DEPRECATED_PARTIALS.');
+
   doStuff();
 }
 

--- a/fixtures/development-svelte-builds/expectation7.js
+++ b/fixtures/development-svelte-builds/expectation7.js
@@ -11,6 +11,10 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
+if (DEPRECATED_PARTIALS && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 
 if (DEPRECATED_CONTROLLERS) {

--- a/fixtures/development-svelte-builds/expectation7.js
+++ b/fixtures/development-svelte-builds/expectation7.js
@@ -12,6 +12,7 @@ if (DEPRECATED_PARTIALS) {
 }
 
 if (DEPRECATED_PARTIALS && someOtherThing()) {
+  throw new Error("You indicated you don't have any deprecations, however you are relying on DEPRECATED_PARTIALS.");
   doStuff();
 }
 

--- a/fixtures/development-svelte-builds/sample.js
+++ b/fixtures/development-svelte-builds/sample.js
@@ -9,6 +9,10 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
+if (DEPRECATED_PARTIALS && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 if (DEPRECATED_CONTROLLERS) {
   ObjectController = class {

--- a/fixtures/production-svelte-builds/expectation6.js
+++ b/fixtures/production-svelte-builds/expectation6.js
@@ -9,6 +9,10 @@ if (false) {
   };
 }
 
+if (false && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 if (true) {
   ObjectController = class {

--- a/fixtures/production-svelte-builds/expectation7.js
+++ b/fixtures/production-svelte-builds/expectation7.js
@@ -9,6 +9,10 @@ if (false) {
   };
 }
 
+if (false && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 
 if (true) {

--- a/fixtures/production-svelte-builds/sample.js
+++ b/fixtures/production-svelte-builds/sample.js
@@ -9,6 +9,10 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
+if (DEPRECATED_PARTIALS && someOtherThing()) {
+  doStuff();
+}
+
 export let ObjectController;
 if (DEPRECATED_CONTROLLERS) {
   ObjectController = class {

--- a/src/utils/macros.js
+++ b/src/utils/macros.js
@@ -98,11 +98,10 @@ module.exports = class Macros {
         if (binding !== undefined) {
           binding.referencePaths.forEach(p => {
             let t = builder.t;
-            if (envFlags.DEBUG) {
-              if (svelteMap[source][flag] === false) {
-                if (!p.parentPath.isIfStatement()) {
-                  return;
-                }
+            // in debug builds add an error after a conditional (to ensure if the
+            // specific branch is taken, an error is thrown)
+            if (envFlags.DEBUG && svelteMap[source][flag] === false) {
+              if (p.parentPath.isIfStatement()) {
                 let consequent = p.parentPath.get('consequent');
                 consequent.unshiftContainer(
                   'body',
@@ -115,10 +114,8 @@ module.exports = class Macros {
                   )
                 );
               }
-            } else {
-              if (p.parentPath.isIfStatement()) {
-                p.replaceWith(t.booleanLiteral(svelteMap[source][flag]));
-              }
+            } else if (envFlags.DEBUG === false) {
+              p.replaceWith(t.booleanLiteral(svelteMap[source][flag]));
             }
           });
 

--- a/src/utils/macros.js
+++ b/src/utils/macros.js
@@ -101,8 +101,9 @@ module.exports = class Macros {
             // in debug builds add an error after a conditional (to ensure if the
             // specific branch is taken, an error is thrown)
             if (envFlags.DEBUG && svelteMap[source][flag] === false) {
-              if (p.parentPath.isIfStatement()) {
-                let consequent = p.parentPath.get('consequent');
+              let parentIfStatement = p.find(p => p.isIfStatement());
+              if (parentIfStatement) {
+                let consequent = parentIfStatement.get('consequent');
                 consequent.unshiftContainer(
                   'body',
                   t.throwStatement(


### PR DESCRIPTION
* Ensure (in production) that _all_ svelte flags are replaced by their evaluated boolean value.
* Ensure that conditions like `if (DEPRECATED_FLAG && otherThing()){ }` receive an error in their consequent.