### PR TITLE
Remove error throwing for svelte guarded features.

### DIFF
--- a/fixtures/development-svelte-builds/expectation6.js
+++ b/fixtures/development-svelte-builds/expectation6.js
@@ -1,9 +1,7 @@
-import { DEPRECATED_PARTIALS, DEPRECATED_CONTROLLERS } from '@ember/features';
+
 
 export let PartialComponentManager;
-if (DEPRECATED_PARTIALS) {
-  throw new Error('You indicated you don\'t have any deprecations, however you are relying on DEPRECATED_PARTIALS.');
-
+if (false /* DEPRECATED_PARTIALS */) {
   PartialComponentManager = class {
     constructor() {
       this.isDone = true;
@@ -11,14 +9,20 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
-if (DEPRECATED_PARTIALS && someOtherThing()) {
-  throw new Error('You indicated you don\'t have any deprecations, however you are relying on DEPRECATED_PARTIALS.');
-
+if (false /* DEPRECATED_PARTIALS */ && someOtherThing()) {
   doStuff();
 }
 
+if (!false /* DEPRECATED_PARTIALS */ && someOtherThing()) {
+  doStuff2();
+}
+
+if (false /* DEPRECATED_PARTIALS */ === false && someOtherThing()) {
+  doStuff3();
+}
+
 export let ObjectController;
-if (DEPRECATED_CONTROLLERS) {
+if (true /* DEPRECATED_CONTROLLERS */) {
   ObjectController = class {
     constructor() {
       this.isDoneAsWell = true;

--- a/fixtures/development-svelte-builds/expectation7.js
+++ b/fixtures/development-svelte-builds/expectation7.js
@@ -1,8 +1,8 @@
-import { DEPRECATED_PARTIALS, DEPRECATED_CONTROLLERS } from '@ember/features';
 export let PartialComponentManager;
 
-if (DEPRECATED_PARTIALS) {
-  throw new Error("You indicated you don't have any deprecations, however you are relying on DEPRECATED_PARTIALS.");
+if (false
+/* DEPRECATED_PARTIALS */
+) {
   PartialComponentManager = class {
     constructor() {
       this.isDone = true;
@@ -11,14 +11,29 @@ if (DEPRECATED_PARTIALS) {
   };
 }
 
-if (DEPRECATED_PARTIALS && someOtherThing()) {
-  throw new Error("You indicated you don't have any deprecations, however you are relying on DEPRECATED_PARTIALS.");
+if (false
+/* DEPRECATED_PARTIALS */
+&& someOtherThing()) {
   doStuff();
+}
+
+if (!false
+/* DEPRECATED_PARTIALS */
+&& someOtherThing()) {
+  doStuff2();
+}
+
+if (false
+/* DEPRECATED_PARTIALS */
+=== false && someOtherThing()) {
+  doStuff3();
 }
 
 export let ObjectController;
 
-if (DEPRECATED_CONTROLLERS) {
+if (true
+/* DEPRECATED_CONTROLLERS */
+) {
   ObjectController = class {
     constructor() {
       this.isDoneAsWell = true;

--- a/fixtures/development-svelte-builds/sample.js
+++ b/fixtures/development-svelte-builds/sample.js
@@ -13,6 +13,14 @@ if (DEPRECATED_PARTIALS && someOtherThing()) {
   doStuff();
 }
 
+if (!DEPRECATED_PARTIALS && someOtherThing()) {
+  doStuff2();
+}
+
+if (DEPRECATED_PARTIALS === false && someOtherThing()) {
+  doStuff3();
+}
+
 export let ObjectController;
 if (DEPRECATED_CONTROLLERS) {
   ObjectController = class {

--- a/fixtures/production-svelte-builds/expectation6.js
+++ b/fixtures/production-svelte-builds/expectation6.js
@@ -1,7 +1,7 @@
 
 
 export let PartialComponentManager;
-if (false) {
+if (false /* DEPRECATED_PARTIALS */) {
   PartialComponentManager = class {
     constructor() {
       this.isDone = true;
@@ -9,12 +9,12 @@ if (false) {
   };
 }
 
-if (false && someOtherThing()) {
+if (false /* DEPRECATED_PARTIALS */ && someOtherThing()) {
   doStuff();
 }
 
 export let ObjectController;
-if (true) {
+if (true /* DEPRECATED_CONTROLLERS */) {
   ObjectController = class {
     constructor() {
       this.isDoneAsWell = true;

--- a/fixtures/production-svelte-builds/expectation7.js
+++ b/fixtures/production-svelte-builds/expectation7.js
@@ -1,6 +1,8 @@
 export let PartialComponentManager;
 
-if (false) {
+if (false
+/* DEPRECATED_PARTIALS */
+) {
   PartialComponentManager = class {
     constructor() {
       this.isDone = true;
@@ -9,13 +11,17 @@ if (false) {
   };
 }
 
-if (false && someOtherThing()) {
+if (false
+/* DEPRECATED_PARTIALS */
+&& someOtherThing()) {
   doStuff();
 }
 
 export let ObjectController;
 
-if (true) {
+if (true
+/* DEPRECATED_CONTROLLERS */
+) {
   ObjectController = class {
     constructor() {
       this.isDoneAsWell = true;

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,6 @@ const Macros = require('./utils/macros');
 const normalizeOptions = require('./utils/normalize-options').normalizeOptions;
 
 function macros(babel) {
-  const t = babel.types;
-
   let options;
 
   return {
@@ -15,7 +13,7 @@ function macros(babel) {
       Program: {
         enter(path, state) {
           options = normalizeOptions(state.opts);
-          this.macroBuilder = new Macros(t, options);
+          this.macroBuilder = new Macros(babel, options);
 
           let body = path.get('body');
 


### PR DESCRIPTION
Adding the error is error prone due to the ability to include arbitrary JS in conditionals, and provides a false sense of security due to the fact that a deprecated feature flag could be used in many locations other than a conditional.

This changes the strategy for svelte features to:

* **always** replace the imported deprecated flag with its boolean value
* **never** add an arbitrary error
* **always** remove feature source import statements that have no specifiers (previously only done in prod builds)