### PR TITLE
Fix same version matching for svelte flags.

### DIFF
--- a/src/utils/normalize-options.js
+++ b/src/utils/normalize-options.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const gte = require('semver').gte;
+const gt = require('semver').gt;
 
 function normalizeOptions(options) {
   let features = options.features || [];
@@ -32,7 +32,7 @@ function normalizeOptions(options) {
 
       if (svelte !== undefined && typeof value === 'string' && svelte[name]) {
         hasSvelteBuild = true;
-        flags[flagName] = svelteMap[featuresSource][flagName] = gte(value, svelte[name]);
+        flags[flagName] = svelteMap[featuresSource][flagName] = gt(value, svelte[name]);
       } else if (typeof value === 'boolean' || value === null) {
         flags[flagName] = featuresMap[featuresSource][flagName] = value;
       } else {

--- a/tests/normalize-options-test.js
+++ b/tests/normalize-options-test.js
@@ -3,6 +3,35 @@
 const normalizeOptions = require('../src/utils/normalize-options').normalizeOptions;
 
 describe('normalizeOptions', function() {
+  it('sets flag to false when svelte version matches the flag version', function() {
+    let actual = normalizeOptions({
+      debugTools: {
+        source: 'whatever',
+      },
+      envFlags: {
+        flags: {
+          DEBUG: true,
+        },
+      },
+      svelte: { foo: '1.2.0' },
+      features: [{ name: 'foo', source: 'foo/features', flags: { ABC: '1.2.0' } }],
+    });
+
+    let expected = {
+      debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
+      envFlags: { envFlagsImport: undefined, flags: { DEBUG: true } },
+      externalizeHelpers: undefined,
+      featureSources: ['foo/features'],
+      features: [{ flags: { ABC: false }, name: 'foo', source: 'foo/features' }],
+      featuresMap: { 'foo/features': {} },
+      hasSvelteBuild: true,
+      svelte: { foo: '1.2.0' },
+      svelteMap: { 'foo/features': { ABC: false } },
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
   it('sets flag to false when svelte version is higher than flag version', function() {
     let actual = normalizeOptions({
       debugTools: {


### PR DESCRIPTION
When both the actual "compliant" version and the "deprecation introduced" version match, the svelted/deprecated feature should be removed. This fixes that scenario.