### PR TITLE
Unify flag handling...

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,33 +4,43 @@ This provides debug macros and feature flagging.
 
 ## Setup
 
-The plugin takes 5 types options: `envFlags`, `features`, `debugTools`, `externalizeHelpers` and `svelte`. The `importSpecifier` is used as a hint to this plugin as to where macros are being imported and completely configurable by the host. Like Babel you can supply your own helpers using the `externalizeHelpers` options.
+The plugin takes 4 types options: `flags`, `svelte`, `debugTools`, and
+`externalizeHelpers`. The `importSpecifier` is used as a hint to this plugin as
+to where macros are being imported and completely configurable by the host.
+
+Like Babel you can supply your own helpers using the `externalizeHelpers`
+options.
 
 ```js
 {
   plugins: [
     ['babel-debug-macros', {
       // @required
-      envFlags: {
-        source: '@ember/env-flags',
-        flags: { DEBUG: true }
-      },
-      // @required
       debugTools: {
+        isDebug: true,
         source: 'debug-tools',
         // @optional
         assertPredicateIndex: 0
       },
-      // @optional
-      features: {
-        name: 'ember-source',
-        source: '@ember/features',
-        flags: { FEATURE_A: false, FEATURE_B: true, DEPRECATED_CONTROLLERS: "2.12.0" }
-      },
+
+      flags: [
+        { source: '@ember/env-flags', flags: { DEBUG: true } },
+        {
+          name: 'ember-source',
+          source: '@ember/features',
+          flags: {
+            FEATURE_A: false,
+            FEATURE_B: true,
+            DEPRECATED_CONTROLLERS: "2.12.0"
+          }
+        }
+      ],
+
       // @optional
       svelte: {
         'ember-source': "2.15.0"
       },
+
       // @optional
       externalizeHelpers: {
         module: true,
@@ -66,12 +76,12 @@ woot();
 Transforms to:
 
 ```javascript
-if (true) {
+if (true /* DEBUG */) {
   console.log('Hello from debug');
 }
 
 let woot;
-if (false) {
+if (false /* FEATURE_A */) {
   woot = () => 'woot';
 } else if (true) {
   woot = () => 'toow';
@@ -141,7 +151,9 @@ let foo = 2;
 
 ## Externalized Helpers
 
-When you externalize helpers you must provide runtime implementations for the above macros. An expansion will still occur, however we will emit references to those runtime helpers.
+When you externalize helpers you must provide runtime implementations for the
+above macros. An expansion will still occur, however we will emit references to
+those runtime helpers.
 
 A global expansion looks like the following:
 
@@ -173,26 +185,28 @@ Expands into:
 
 # Svelte
 
-Svelte allows for consumers to opt into stripping deprecated code from your dependecies. By adding a package name and minimum version that contains no deprecations, that code will be compiled away.
+Svelte allows for consumers to opt into stripping deprecated code from your
+dependecies. By adding a package name and minimum version that contains no
+deprecations, that code will be compiled away.
 
-For example, consider you are on `ember-source@2.10.0` and you have no deprecations. All deprecated code in `ember-source` that is `<=2.10.0` will be removed.
+For example, consider you are on `ember-source@2.10.0` and you have no
+deprecations. All deprecated code in `ember-source` that is `<=2.10.0` will be
+removed.
 
 ```
-...
+
 svelte: {
   "ember-source": "2.10.0"
 }
-...
+
 ```
 
-Now if you bump to `ember-source@2.11.0` you may encounter new deprecations. The workflow would then be to clear out all deprecations and then bump the version in the `svelte` options.
+Now if you bump to `ember-source@2.11.0` you may encounter new deprecations.
+The workflow would then be to clear out all deprecations and then bump the
+version in the `svelte` options.
 
 ```
 svelte: {
   "ember-source": "2.11.0"
 }
 ```
-
-# Hygenic
-
-As you may notice that we inject `DEBUG` into the code when we expand the macro. We guarantee that the binding is unique when injected and follow the local binding name if it is imported directly.

--- a/fixtures/debug-flag/expectation6.js
+++ b/fixtures/debug-flag/expectation6.js
@@ -1,5 +1,5 @@
 
 
-if (true) {
+if (true /* DEBUG */) {
   console.log('woot');
 }

--- a/fixtures/debug-flag/expectation7.js
+++ b/fixtures/debug-flag/expectation7.js
@@ -1,3 +1,5 @@
-if (true) {
+if (true
+/* DEBUG */
+) {
   console.log('woot');
 }

--- a/fixtures/ember-cli-babel-config/expectation6.js
+++ b/fixtures/ember-cli-babel-config/expectation6.js
@@ -1,6 +1,6 @@
 
 
-if (true) {
+if (true /* DEBUG */) {
   doStuff();
 }
 

--- a/fixtures/ember-cli-babel-config/expectation7.js
+++ b/fixtures/ember-cli-babel-config/expectation7.js
@@ -1,4 +1,6 @@
-if (true) {
+if (true
+/* DEBUG */
+) {
   doStuff();
 }
 

--- a/fixtures/inject-env-flags/expectation6.js
+++ b/fixtures/inject-env-flags/expectation6.js
@@ -1,11 +1,11 @@
 
 
 let testing;
-if (false) {
+if (false /* TESTING */) {
   testing = 'WOOT';
 }
 
 let debug;
-if (true) {
+if (true /* DEBUG */) {
   debug = 'DEBUG';
 }

--- a/fixtures/inject-env-flags/expectation7.js
+++ b/fixtures/inject-env-flags/expectation7.js
@@ -1,11 +1,15 @@
 let testing;
 
-if (false) {
+if (false
+/* TESTING */
+) {
   testing = 'WOOT';
 }
 
 let debug;
 
-if (true) {
+if (true
+/* DEBUG */
+) {
   debug = 'DEBUG';
 }

--- a/fixtures/inline-feature-flags/expectation6.js
+++ b/fixtures/inline-feature-flags/expectation6.js
@@ -1,18 +1,18 @@
 
 
 let a;
-if (false) {
+if (false /* FEATURE_A */) {
   a = () => console.log('hello');
-} else if (true) {
+} else if (true /* FEATURE_B */) {
   a = () => console.log('bye');
 }
 
-if (!false) {
+if (!false /* FEATURE_A */) {
   console.log('stuff');
 }
 
-a = false ? 'hello' : 'bye';
+a = false /* FEATURE_A */ ? 'hello' : 'bye';
 
-if (false && window.foo && window.bar) {
+if (false /* FEATURE_A */ && window.foo && window.bar) {
   console.log('wheeee');
 }

--- a/fixtures/inline-feature-flags/expectation7.js
+++ b/fixtures/inline-feature-flags/expectation7.js
@@ -1,17 +1,27 @@
 let a;
 
-if (false) {
+if (false
+/* FEATURE_A */
+) {
   a = () => console.log('hello');
-} else if (true) {
+} else if (true
+/* FEATURE_B */
+) {
   a = () => console.log('bye');
 }
 
-if (!false) {
+if (!false
+/* FEATURE_A */
+) {
   console.log('stuff');
 }
 
-a = false ? 'hello' : 'bye';
+a = false
+/* FEATURE_A */
+? 'hello' : 'bye';
 
-if (false && window.foo && window.bar) {
+if (false
+/* FEATURE_A */
+&& window.foo && window.bar) {
   console.log('wheeee');
 }

--- a/fixtures/runtime-feature-flags/expectation6.js
+++ b/fixtures/runtime-feature-flags/expectation6.js
@@ -1,6 +1,6 @@
 import { FEATURE_B } from '@ember/features';
 
-if (true) {
+if (true /* FEATURE_A */) {
   console.log('woot');
 }
 

--- a/fixtures/runtime-feature-flags/expectation7.js
+++ b/fixtures/runtime-feature-flags/expectation7.js
@@ -1,6 +1,8 @@
 import { FEATURE_B } from '@ember/features';
 
-if (true) {
+if (true
+/* FEATURE_A */
+) {
   console.log('woot');
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,13 +22,13 @@ function macros(babel) {
               let importPath = item.node.source.value;
 
               let debugToolsImport = options.debugTools.debugToolsImport;
-              let envFlagsImport = options.envFlags.envFlagsImport;
 
               if (debugToolsImport && debugToolsImport === importPath) {
                 this.macroBuilder.collectDebugToolsSpecifiers(item.get('specifiers'));
               }
-              if (envFlagsImport && envFlagsImport === importPath) {
-                this.macroBuilder.collectEnvFlagSpecifiers(item.get('specifiers'));
+
+              if (importPath in options.flags) {
+                this.macroBuilder.collectFlagSpecifiers(item.get('specifiers'));
               }
             }
           });

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ function macros(babel) {
           });
 
           path.remove();
+          path.scope.removeOwnBinding(localBindingName);
         }
       },
 

--- a/src/utils/builder.js
+++ b/src/utils/builder.js
@@ -6,6 +6,7 @@ module.exports = class Builder {
     this.module = options.module;
     this.global = options.global;
     this.assertPredicateIndex = options.assertPredicateIndex;
+    this.isDebug = options.isDebug;
     this.expressions = [];
   }
 
@@ -170,9 +171,9 @@ module.exports = class Builder {
   /**
    * Performs the actually expansion of macros
    */
-  expandMacros(debugFlag) {
+  expandMacros() {
     let t = this.t;
-    let flag = t.booleanLiteral(debugFlag);
+    let flag = t.booleanLiteral(this.isDebug);
     for (let i = 0; i < this.expressions.length; i++) {
       let expression = this.expressions[i];
       let exp = expression[0];

--- a/src/utils/macros.js
+++ b/src/utils/macros.js
@@ -14,6 +14,7 @@ module.exports = class Macros {
       module: this.debugHelpers.module,
       global: this.debugHelpers.global,
       assertPredicateIndex: options.debugTools.assertPredicateIndex,
+      isDebug: options.debugTools.isDebug,
     });
   }
 
@@ -22,8 +23,7 @@ module.exports = class Macros {
    * adds the debug binding if missing from the env-flags module.
    */
   expand(path) {
-    // TODO: fix determination of "debug" or not
-    this.builder.expandMacros(true);
+    this.builder.expandMacros();
 
     this._cleanImports(path);
   }

--- a/src/utils/normalize-options.js
+++ b/src/utils/normalize-options.js
@@ -9,10 +9,20 @@ function parseDebugTools(options) {
     throw new Error('You must specify `debugTools.source`');
   }
 
+  let isDebug = debugTools.isDebug;
   let debugToolsImport = debugTools.source;
   let assertPredicateIndex = debugTools.assertPredicateIndex;
 
+  if (options.envFlags && isDebug === undefined) {
+    isDebug = options.envFlags.flags.DEBUG;
+  }
+
+  if (isDebug === undefined) {
+    throw new Error('You must specify `debugTools.isDebug`');
+  }
+
   return {
+    isDebug,
     debugToolsImport,
     assertPredicateIndex,
   };

--- a/src/utils/normalize-options.js
+++ b/src/utils/normalize-options.js
@@ -2,50 +2,8 @@
 
 const gt = require('semver').gt;
 
-function normalizeOptions(options) {
-  let features = options.features || [];
-  let debugTools = options.debugTools;
-  let envFlags = options.envFlags;
-  let externalizeHelpers = options.externalizeHelpers;
-  let svelte = options.svelte;
-
-  let featureSources = [];
-  let featuresMap = {};
-  let svelteMap = {};
-  let hasSvelteBuild = false;
-
-  if (!Array.isArray(features)) {
-    features = [features];
-  }
-
-  features = features.map(feature => {
-    let featuresSource = feature.source;
-    featureSources.push(featuresSource);
-    let name = feature.name;
-
-    let flags = {};
-    featuresMap[featuresSource] = {};
-    svelteMap[featuresSource] = {};
-
-    Object.keys(feature.flags).forEach(flagName => {
-      let value = feature.flags[flagName];
-
-      if (svelte !== undefined && typeof value === 'string' && svelte[name]) {
-        hasSvelteBuild = true;
-        flags[flagName] = svelteMap[featuresSource][flagName] = gt(value, svelte[name]);
-      } else if (typeof value === 'boolean' || value === null) {
-        flags[flagName] = featuresMap[featuresSource][flagName] = value;
-      } else {
-        flags[flagName] = featuresMap[featuresSource][flagName] = true;
-      }
-    });
-
-    return {
-      name,
-      source: feature.source,
-      flags,
-    };
-  });
+function parseDebugTools(options) {
+  let debugTools = options.debugTools || {};
 
   if (!debugTools) {
     throw new Error('You must specify `debugTools.source`');
@@ -54,34 +12,65 @@ function normalizeOptions(options) {
   let debugToolsImport = debugTools.source;
   let assertPredicateIndex = debugTools.assertPredicateIndex;
 
-  let envFlagsImport;
-  let _envFlags = {};
+  return {
+    debugToolsImport,
+    assertPredicateIndex,
+  };
+}
 
-  if (envFlags) {
-    envFlagsImport = envFlags.source;
-    if (envFlags.flags) {
-      _envFlags = envFlags.flags;
+function evaluateFlagValue(options, name, flagName, flagValue) {
+  let svelte = options.svelte;
+
+  if (typeof flagValue === 'string') {
+    if (svelte && svelte[name]) {
+      return gt(flagValue, svelte[name]);
+    } else {
+      return null;
     }
+  } else if (typeof flagValue === 'boolean' || flagValue === null) {
+    return flagValue;
   } else {
-    throw new Error('You must specify envFlags.flags.DEBUG at minimum.');
+    throw new Error(`Invalid value specified (${flagValue}) for ${flagName} by ${name}`);
+  }
+}
+
+function parseFlags(options) {
+  let flagsProvided = options.flags || [];
+
+  let combinedFlags = {};
+  flagsProvided.forEach(flagsDefinition => {
+    let source = flagsDefinition.source;
+    let flagsForSource = (combinedFlags[source] = combinedFlags[source] || {});
+
+    for (let flagName in flagsDefinition.flags) {
+      let flagValue = flagsDefinition.flags[flagName];
+
+      flagsForSource[flagName] = evaluateFlagValue(
+        options,
+        flagsDefinition.name,
+        flagName,
+        flagValue
+      );
+    }
+  });
+
+  return combinedFlags;
+}
+
+function normalizeOptions(options) {
+  let features = options.features || [];
+  let externalizeHelpers = options.externalizeHelpers;
+  let svelte = options.svelte;
+
+  if (!Array.isArray(features)) {
+    features = [features];
   }
 
   return {
-    featureSources,
     externalizeHelpers,
-    features,
-    featuresMap,
-    svelteMap,
-    hasSvelteBuild,
+    flags: parseFlags(options),
     svelte,
-    envFlags: {
-      envFlagsImport,
-      flags: _envFlags,
-    },
-    debugTools: {
-      debugToolsImport,
-      assertPredicateIndex,
-    },
+    debugTools: parseDebugTools(options),
   };
 }
 

--- a/src/utils/normalize-options.js
+++ b/src/utils/normalize-options.js
@@ -54,6 +54,47 @@ function parseFlags(options) {
     }
   });
 
+  let legacyEnvFlags = options.envFlags;
+  if (legacyEnvFlags) {
+    let source = legacyEnvFlags.source;
+    combinedFlags[source] = combinedFlags[source] || {};
+
+    for (let flagName in legacyEnvFlags.flags) {
+      let flagValue = legacyEnvFlags.flags[flagName];
+      combinedFlags[source][flagName] = evaluateFlagValue(options, null, flagName, flagValue);
+    }
+  }
+
+  let legacyFeatures = options.features;
+  if (legacyFeatures) {
+    if (!Array.isArray(legacyFeatures)) {
+      legacyFeatures = [legacyFeatures];
+    }
+
+    legacyFeatures.forEach(flagsDefinition => {
+      let source = flagsDefinition.source;
+      let flagsForSource = (combinedFlags[source] = combinedFlags[source] || {});
+
+      for (let flagName in flagsDefinition.flags) {
+        let flagValue = flagsDefinition.flags[flagName];
+
+        flagsForSource[flagName] = evaluateFlagValue(
+          options,
+          flagsDefinition.name,
+          flagName,
+          flagValue
+        );
+      }
+    });
+  }
+
+  if (legacyFeatures || legacyEnvFlags) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'babel-plugin-debug-macros configuration API has changed, please update your configuration'
+    );
+  }
+
   return combinedFlags;
 }
 

--- a/tests/create-tests.js
+++ b/tests/create-tests.js
@@ -36,6 +36,7 @@ function createTests(options) {
               },
             ],
             debugTools: {
+              isDebug: false,
               source: '@ember/debug-tools',
             },
           },
@@ -58,6 +59,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
               assertPredicateIndex: 0,
             },
@@ -89,6 +91,7 @@ function createTests(options) {
               global: 'Ember',
             },
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
               assertPredicateIndex: 0,
             },
@@ -147,6 +150,7 @@ function createTests(options) {
               global: '__debugHelpers__',
             },
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
             flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
@@ -173,6 +177,7 @@ function createTests(options) {
               global: 'Ember',
             },
             debugTools: {
+              isDebug: true,
               source: '@ember/debug',
               assertPredicateIndex: 1,
             },
@@ -201,6 +206,7 @@ function createTests(options) {
               global: 'Ember',
             },
             debugTools: {
+              isDebug: true,
               source: '@ember/debug',
               assertPredicateIndex: 1,
             },
@@ -224,6 +230,7 @@ function createTests(options) {
               module: true,
             },
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
             flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
@@ -243,6 +250,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
             flags: [
@@ -285,6 +293,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
             flags: [{ source: '@ember/env-flags', flags: { DEBUG: true, TESTING: false } }],
@@ -305,6 +314,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
             flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
@@ -325,6 +335,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: false,
               source: '@ember/debug-tools',
             },
             flags: [
@@ -353,6 +364,7 @@ function createTests(options) {
           DebugToolsPlugin,
           {
             debugTools: {
+              isDebug: false,
               source: '@ember/debug-tools',
             },
             flags: [
@@ -392,6 +404,7 @@ function createTests(options) {
               },
             ],
             debugTools: {
+              isDebug: true,
               source: '@ember/debug-tools',
             },
           },

--- a/tests/create-tests.js
+++ b/tests/create-tests.js
@@ -15,18 +15,14 @@ function createTests(options) {
         [
           DebugToolsPlugin,
           {
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: false,
-              },
-            },
-            debugTools: {
-              source: '@ember/debug-tools',
-            },
-            features: [
+            flags: [
               {
-                name: 'ember-source',
+                source: '@ember/env-flags',
+                flags: {
+                  DEBUG: false,
+                },
+              },
+              {
                 source: '@ember/features',
                 flags: {
                   FEATURE_A: false,
@@ -34,6 +30,9 @@ function createTests(options) {
                 },
               },
             ],
+            debugTools: {
+              source: '@ember/debug-tools',
+            },
           },
         ],
       ],
@@ -57,12 +56,7 @@ function createTests(options) {
               source: '@ember/debug-tools',
               assertPredicateIndex: 0,
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
           },
         ],
       ],
@@ -93,12 +87,7 @@ function createTests(options) {
               source: '@ember/debug-tools',
               assertPredicateIndex: 0,
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
           },
         ],
 
@@ -155,12 +144,7 @@ function createTests(options) {
             debugTools: {
               source: '@ember/debug-tools',
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
           },
         ],
       ],
@@ -169,7 +153,7 @@ function createTests(options) {
     h.generateTest('global-external-helpers');
   });
 
-  describe('ember-cli-babel default configuration', function() {
+  describe('ember-cli-babel default configuration (legacy config API)', function() {
     let h = transformTestHelper({
       presets,
       plugins: [
@@ -197,6 +181,29 @@ function createTests(options) {
     h.generateTest('ember-cli-babel-config');
   });
 
+  describe('ember-cli-babel default configuration', function() {
+    let h = transformTestHelper({
+      presets,
+      plugins: [
+        [
+          DebugToolsPlugin,
+          {
+            externalizeHelpers: {
+              global: 'Ember',
+            },
+            debugTools: {
+              source: '@ember/debug',
+              assertPredicateIndex: 1,
+            },
+            flags: [{ source: '@glimmer/env', flags: { DEBUG: true } }],
+          },
+        ],
+      ],
+    });
+
+    h.generateTest('ember-cli-babel-config');
+  });
+
   describe('Retain Module External Test Helpers', function() {
     let h = transformTestHelper({
       presets,
@@ -210,12 +217,7 @@ function createTests(options) {
             debugTools: {
               source: '@ember/debug-tools',
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
           },
         ],
       ],
@@ -224,7 +226,7 @@ function createTests(options) {
     h.generateTest('retain-module-external-helpers');
   });
 
-  describe('Development Svelte Builds', function() {
+  describe('Svelte Builds', function() {
     let h = transformTestHelper({
       presets,
       plugins: [
@@ -234,18 +236,8 @@ function createTests(options) {
             debugTools: {
               source: '@ember/debug-tools',
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
-
-            svelte: {
-              'ember-source': '2.15.0',
-            },
-
-            features: [
+            flags: [
+              { source: '@ember/env-flags', flags: { DEBUG: true } },
               {
                 name: 'my-app',
                 source: 'my-app/features',
@@ -264,60 +256,16 @@ function createTests(options) {
                 },
               },
             ],
+
+            svelte: {
+              'ember-source': '2.15.0',
+            },
           },
         ],
       ],
     });
 
     h.generateTest('development-svelte-builds');
-  });
-
-  describe('Production Svelte Builds', function() {
-    let h = transformTestHelper({
-      presets,
-      plugins: [
-        [
-          DebugToolsPlugin,
-          {
-            debugTools: {
-              source: '@ember/debug-tools',
-            },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: false,
-              },
-            },
-
-            svelte: {
-              'ember-source': '2.15.0',
-            },
-
-            features: [
-              {
-                name: 'my-app',
-                source: 'my-app/features',
-                flags: {
-                  FEATURE_A: false,
-                  FEATURE_B: true,
-                },
-              },
-              // Note this going to have to be concated in by each lib
-              {
-                name: 'ember-source',
-                source: '@ember/features',
-                flags: {
-                  DEPRECATED_PARTIALS: '2.14.0',
-                  DEPRECATED_CONTROLLERS: '2.16.0',
-                },
-              },
-            ],
-          },
-        ],
-      ],
-    });
-
-    h.generateTest('production-svelte-builds');
   });
 
   describe('Inline Env Flags', function() {
@@ -327,17 +275,10 @@ function createTests(options) {
         [
           DebugToolsPlugin,
           {
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-                TESTING: false,
-              },
-            },
             debugTools: {
               source: '@ember/debug-tools',
             },
-            features: [],
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true, TESTING: false } }],
           },
         ],
       ],
@@ -357,12 +298,7 @@ function createTests(options) {
             debugTools: {
               source: '@ember/debug-tools',
             },
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
-              },
-            },
+            flags: [{ source: '@ember/env-flags', flags: { DEBUG: true } }],
           },
         ],
       ],
@@ -379,23 +315,19 @@ function createTests(options) {
         [
           DebugToolsPlugin,
           {
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: false,
-              },
-            },
             debugTools: {
               source: '@ember/debug-tools',
             },
-            features: {
-              name: 'ember-source',
-              source: '@ember/features',
-              flags: {
-                FEATURE_A: true,
-                FEATURE_B: null,
+            flags: [
+              { source: '@ember/env-flags', flags: { DEBUG: false } },
+              {
+                source: '@ember/features',
+                flags: {
+                  FEATURE_A: true,
+                  FEATURE_B: null,
+                },
               },
-            },
+            ],
           },
         ],
       ],
@@ -411,23 +343,19 @@ function createTests(options) {
         [
           DebugToolsPlugin,
           {
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: false,
-              },
-            },
             debugTools: {
               source: '@ember/debug-tools',
             },
-            features: {
-              name: 'ember-source',
-              source: '@ember/features',
-              flags: {
-                FEATURE_A: true,
-                FEATURE_B: null,
+            flags: [
+              { source: '@ember/env-flags', flags: { DEBUG: false } },
+              {
+                source: '@ember/features',
+                flags: {
+                  FEATURE_A: true,
+                  FEATURE_B: null,
+                },
               },
-            },
+            ],
           },
         ],
       ],
@@ -443,22 +371,19 @@ function createTests(options) {
         [
           DebugToolsPlugin,
           {
-            envFlags: {
-              source: '@ember/env-flags',
-              flags: {
-                DEBUG: true,
+            flags: [
+              { source: '@ember/env-flags', flags: { DEBUG: true } },
+              {
+                name: 'ember-source',
+                source: '@ember/features',
+                flags: {
+                  FOO_BAR: false,
+                  WIDGET_WOO: false,
+                },
               },
-            },
+            ],
             debugTools: {
               source: '@ember/debug-tools',
-            },
-            features: {
-              name: 'ember-source',
-              source: '@ember/features',
-              flags: {
-                FOO_BAR: false,
-                WIDGET_WOO: false,
-              },
             },
           },
         ],

--- a/tests/create-tests.js
+++ b/tests/create-tests.js
@@ -2,11 +2,16 @@
 
 const DebugToolsPlugin = require('..');
 const fs = require('fs');
+const CONSOLE = Object.assign({}, console);
 
 function createTests(options) {
   const babelVersion = options.babelVersion;
   const presets = options.presets;
   const transform = options.transform;
+
+  afterEach(function() {
+    Object.assign(console, CONSOLE);
+  });
 
   describe('Feature Flags', function() {
     const h = transformTestHelper({
@@ -154,6 +159,10 @@ function createTests(options) {
   });
 
   describe('ember-cli-babel default configuration (legacy config API)', function() {
+    beforeEach(function() {
+      console.warn = () => {}; // eslint-disable-line
+    });
+
     let h = transformTestHelper({
       presets,
       plugins: [

--- a/tests/normalize-options-test.js
+++ b/tests/normalize-options-test.js
@@ -3,7 +3,16 @@
 const normalizeOptions = require('../src/utils/normalize-options').normalizeOptions;
 
 describe('normalizeOptions', function() {
+  let originalConsole = Object.assign({}, console);
+
+  afterEach(function() {
+    Object.assign(console, originalConsole);
+  });
+
   it('converts "old style" options into the newer style (with deprecation)', function() {
+    let warnings = [];
+    console.warn = warning => warnings.push(warning); // eslint-disable-line
+
     let actual = normalizeOptions({
       envFlags: {
         source: '@ember/env-flags',
@@ -39,6 +48,9 @@ describe('normalizeOptions', function() {
     };
 
     expect(actual).toEqual(expected);
+    expect(warnings).toEqual([
+      'babel-plugin-debug-macros configuration API has changed, please update your configuration',
+    ]);
   });
 
   it('sets flag to false when svelte version matches the flag version', function() {

--- a/tests/normalize-options-test.js
+++ b/tests/normalize-options-test.js
@@ -3,6 +3,44 @@
 const normalizeOptions = require('../src/utils/normalize-options').normalizeOptions;
 
 describe('normalizeOptions', function() {
+  it('converts "old style" options into the newer style (with deprecation)', function() {
+    let actual = normalizeOptions({
+      envFlags: {
+        source: '@ember/env-flags',
+        flags: {
+          DEBUG: false,
+        },
+      },
+      debugTools: {
+        source: '@ember/debug-tools',
+      },
+      features: {
+        name: 'ember-source',
+        source: '@ember/features',
+        flags: {
+          FEATURE_A: true,
+          FEATURE_B: null,
+        },
+      },
+    });
+
+    let expected = {
+      debugTools: { assertPredicateIndex: undefined, debugToolsImport: '@ember/debug-tools' },
+      flags: {
+        '@ember/env-flags': {
+          DEBUG: false,
+        },
+        '@ember/features': {
+          FEATURE_A: true,
+          FEATURE_B: null,
+        },
+      },
+      externalizeHelpers: undefined,
+    };
+
+    expect(actual).toEqual(expected);
+  });
+
   it('sets flag to false when svelte version matches the flag version', function() {
     let actual = normalizeOptions({
       debugTools: {

--- a/tests/normalize-options-test.js
+++ b/tests/normalize-options-test.js
@@ -34,7 +34,11 @@ describe('normalizeOptions', function() {
     });
 
     let expected = {
-      debugTools: { assertPredicateIndex: undefined, debugToolsImport: '@ember/debug-tools' },
+      debugTools: {
+        isDebug: false,
+        assertPredicateIndex: undefined,
+        debugToolsImport: '@ember/debug-tools',
+      },
       flags: {
         '@ember/env-flags': {
           DEBUG: false,
@@ -57,6 +61,7 @@ describe('normalizeOptions', function() {
     let actual = normalizeOptions({
       debugTools: {
         source: 'whatever',
+        isDebug: true,
       },
       flags: [
         { name: 'ember-source', source: '@glimmer/env', flags: { DEBUG: true } },
@@ -75,7 +80,7 @@ describe('normalizeOptions', function() {
     });
 
     let expected = {
-      debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
+      debugTools: { isDebug: true, assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
       flags: {
         '@glimmer/env': {
           DEBUG: true,
@@ -99,6 +104,7 @@ describe('normalizeOptions', function() {
     let actual = normalizeOptions({
       debugTools: {
         source: 'whatever',
+        isDebug: true,
       },
       svelte: { foo: '1.2.0' },
       flags: [
@@ -108,7 +114,7 @@ describe('normalizeOptions', function() {
     });
 
     let expected = {
-      debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
+      debugTools: { isDebug: true, assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
       flags: {
         'foo/features': { ABC: false },
         whatever: { DEBUG: true },
@@ -124,6 +130,7 @@ describe('normalizeOptions', function() {
     let actual = normalizeOptions({
       debugTools: {
         source: 'whatever',
+        isDebug: true,
       },
       svelte: { foo: '1.0.0' },
       flags: [
@@ -133,7 +140,7 @@ describe('normalizeOptions', function() {
     });
 
     let expected = {
-      debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
+      debugTools: { isDebug: true, assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
       flags: {
         'foo/features': { ABC: true },
         whatever: { DEBUG: true },
@@ -149,6 +156,7 @@ describe('normalizeOptions', function() {
     let actual = normalizeOptions({
       debugTools: {
         source: 'whatever',
+        isDebug: true,
       },
       svelte: { foo: '1.2.0' },
       flags: [
@@ -158,7 +166,7 @@ describe('normalizeOptions', function() {
     });
 
     let expected = {
-      debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
+      debugTools: { isDebug: true, assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
       flags: {
         'foo/features': { ABC: false },
         whatever: { DEBUG: true },

--- a/tests/normalize-options-test.js
+++ b/tests/normalize-options-test.js
@@ -8,25 +8,38 @@ describe('normalizeOptions', function() {
       debugTools: {
         source: 'whatever',
       },
-      envFlags: {
-        flags: {
-          DEBUG: true,
+      flags: [
+        { name: 'ember-source', source: '@glimmer/env', flags: { DEBUG: true } },
+        {
+          name: 'ember-source',
+          source: '@ember/deprecated-features',
+          flags: { PARTIALS: '1.2.0' },
         },
-      },
-      svelte: { foo: '1.2.0' },
-      features: [{ name: 'foo', source: 'foo/features', flags: { ABC: '1.2.0' } }],
+        {
+          name: 'ember-source',
+          source: '@ember/canary-features',
+          flags: { TRACKED: null, GETTERS: true },
+        },
+      ],
+      svelte: { 'ember-source': '1.2.0' },
     });
 
     let expected = {
       debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
-      envFlags: { envFlagsImport: undefined, flags: { DEBUG: true } },
+      flags: {
+        '@glimmer/env': {
+          DEBUG: true,
+        },
+        '@ember/deprecated-features': {
+          PARTIALS: false,
+        },
+        '@ember/canary-features': {
+          TRACKED: null,
+          GETTERS: true,
+        },
+      },
       externalizeHelpers: undefined,
-      featureSources: ['foo/features'],
-      features: [{ flags: { ABC: false }, name: 'foo', source: 'foo/features' }],
-      featuresMap: { 'foo/features': {} },
-      hasSvelteBuild: true,
-      svelte: { foo: '1.2.0' },
-      svelteMap: { 'foo/features': { ABC: false } },
+      svelte: { 'ember-source': '1.2.0' },
     };
 
     expect(actual).toEqual(expected);
@@ -37,25 +50,21 @@ describe('normalizeOptions', function() {
       debugTools: {
         source: 'whatever',
       },
-      envFlags: {
-        flags: {
-          DEBUG: true,
-        },
-      },
       svelte: { foo: '1.2.0' },
-      features: [{ name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0' } }],
+      flags: [
+        { name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0' } },
+        { source: 'whatever', flags: { DEBUG: true } },
+      ],
     });
 
     let expected = {
       debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
-      envFlags: { envFlagsImport: undefined, flags: { DEBUG: true } },
+      flags: {
+        'foo/features': { ABC: false },
+        whatever: { DEBUG: true },
+      },
       externalizeHelpers: undefined,
-      featureSources: ['foo/features'],
-      features: [{ flags: { ABC: false }, name: 'foo', source: 'foo/features' }],
-      featuresMap: { 'foo/features': {} },
-      hasSvelteBuild: true,
       svelte: { foo: '1.2.0' },
-      svelteMap: { 'foo/features': { ABC: false } },
     };
 
     expect(actual).toEqual(expected);
@@ -66,25 +75,21 @@ describe('normalizeOptions', function() {
       debugTools: {
         source: 'whatever',
       },
-      envFlags: {
-        flags: {
-          DEBUG: true,
-        },
-      },
       svelte: { foo: '1.0.0' },
-      features: [{ name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0' } }],
+      flags: [
+        { name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0' } },
+        { source: 'whatever', flags: { DEBUG: true } },
+      ],
     });
 
     let expected = {
       debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
-      envFlags: { envFlagsImport: undefined, flags: { DEBUG: true } },
+      flags: {
+        'foo/features': { ABC: true },
+        whatever: { DEBUG: true },
+      },
       externalizeHelpers: undefined,
-      featureSources: ['foo/features'],
-      features: [{ flags: { ABC: true }, name: 'foo', source: 'foo/features' }],
-      featuresMap: { 'foo/features': {} },
-      hasSvelteBuild: true,
       svelte: { foo: '1.0.0' },
-      svelteMap: { 'foo/features': { ABC: true } },
     };
 
     expect(actual).toEqual(expected);
@@ -95,25 +100,21 @@ describe('normalizeOptions', function() {
       debugTools: {
         source: 'whatever',
       },
-      envFlags: {
-        flags: {
-          DEBUG: true,
-        },
-      },
       svelte: { foo: '1.2.0' },
-      features: [{ name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0-beta.1' } }],
+      flags: [
+        { name: 'foo', source: 'foo/features', flags: { ABC: '1.1.0-beta.1' } },
+        { source: 'whatever', flags: { DEBUG: true } },
+      ],
     });
 
     let expected = {
       debugTools: { assertPredicateIndex: undefined, debugToolsImport: 'whatever' },
-      envFlags: { envFlagsImport: undefined, flags: { DEBUG: true } },
+      flags: {
+        'foo/features': { ABC: false },
+        whatever: { DEBUG: true },
+      },
       externalizeHelpers: undefined,
-      featureSources: ['foo/features'],
-      features: [{ flags: { ABC: false }, name: 'foo', source: 'foo/features' }],
-      featuresMap: { 'foo/features': {} },
-      hasSvelteBuild: true,
       svelte: { foo: '1.2.0' },
-      svelteMap: { 'foo/features': { ABC: false } },
     };
 
     expect(actual).toEqual(expected);


### PR DESCRIPTION
* Remove `envFlags`
* Remove `features`
* Add inline comments for flag replacments
* Add `isDebug` configuration flag to `debugTools` config (no longer infer it from `envFlags`)
* Make flag processing happen directly in the visitor (simplifies logic significantly)